### PR TITLE
Removed 'numexpr==2.6.4 \' in the Dockerfile, as it causes a failure …

### DIFF
--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -14,7 +14,6 @@ RUN pip install -U geopandas \
                    fiona \
                    six \
                    pyproj \
-                   numexpr==2.6.4 \
                    elasticsearch \
                    geojson \
                    plotly \


### PR DESCRIPTION
Removed 'numexpr==2.6.4 \' in the Dockerfile, as it causes a failure when building Jupyter. 

docker-compose up is successful with it removed.